### PR TITLE
feat: 이메일 발송 실패 이력 저장 및 재시도 스케줄러 구현

### DIFF
--- a/domain/notification/connector/out-bound/src/main/java/com/example/outbound/email/FailEmailOutConnector.java
+++ b/domain/notification/connector/out-bound/src/main/java/com/example/outbound/email/FailEmailOutConnector.java
@@ -1,0 +1,64 @@
+package com.example.outbound.email;
+
+import com.example.notification.model.FailEmailModel;
+import com.example.rdbrepository.FailEmailEntity;
+import com.example.rdbrepository.FailEmailEntityRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@AllArgsConstructor
+public class FailEmailOutConnector {
+
+    private final FailEmailEntityRepository failEmailEntityRepository;
+
+    public List<FailEmailModel> findUnresolved() {
+        return failEmailEntityRepository.findByResolvedFalse().stream()
+                .map(this::toModel).collect(Collectors.toList());
+    }
+
+    public void saveAll(List<FailEmailModel> failEmails) {
+        List<FailEmailEntity> entities = failEmails.stream()
+                .map(model -> FailEmailEntity.builder()
+                        .id(model.getId())
+                        .toEmail(model.getToEmail())
+                        .subject(model.getSubject())
+                        .content(model.getContent())
+                        .resolved(model.isResolved())
+                        .createdAt(model.getCreatedAt())
+                        .build())
+                .toList();
+        failEmailEntityRepository.saveAll(entities);
+    }
+
+
+    public FailEmailModel createFailEmail(FailEmailModel failEmailModel){
+        FailEmailEntity failEmailEntity = FailEmailEntity
+                .builder()
+                .id(failEmailModel.getId())
+                .content(failEmailModel.getContent())
+                .resolved(failEmailModel.isResolved())
+                .toEmail(failEmailModel.getToEmail())
+                .subject(failEmailModel.getSubject())
+                .createdAt(failEmailModel.getCreatedAt())
+                .build();
+        return toModel(failEmailEntityRepository.save(failEmailEntity));
+    }
+
+    private FailEmailModel toModel(FailEmailEntity failEmailEntity) {
+        return FailEmailModel
+                .builder()
+                .id(failEmailEntity.getId())
+                .toEmail(failEmailEntity.getToEmail())
+                .content(failEmailEntity.getContent())
+                .resolved(failEmailEntity.isResolved())
+                .subject(failEmailEntity.getSubject())
+                .createdAt(failEmailEntity.getCreatedAt())
+                .build();
+    }
+}

--- a/domain/notification/core/model/src/main/java/com/example/notification/model/FailEmailModel.java
+++ b/domain/notification/core/model/src/main/java/com/example/notification/model/FailEmailModel.java
@@ -1,0 +1,32 @@
+package com.example.notification.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FailEmailModel {
+
+    private Long id;
+
+    private String toEmail;
+
+    private String subject;
+
+    private String content;
+
+    private boolean resolved;
+
+    private LocalDateTime createdAt;
+
+
+    public void markResolved(){
+        this.resolved = true;
+    }
+}

--- a/domain/notification/core/service/src/main/java/com/example/notification/email/EmailRetryScheduler.java
+++ b/domain/notification/core/service/src/main/java/com/example/notification/email/EmailRetryScheduler.java
@@ -1,0 +1,35 @@
+package com.example.notification.email;
+
+import com.example.notification.model.FailEmailModel;
+import com.example.outbound.email.FailEmailOutConnector;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@AllArgsConstructor
+public class EmailRetryScheduler {
+
+    private final FailEmailOutConnector failEmailOutConnector;
+
+    private final EmailService emailService;
+
+    @Scheduled(fixedDelay = 10_000) // 10초마다 재시도
+    public void retryFailedEmails() {
+        List<FailEmailModel> fails = failEmailOutConnector.findUnresolved();
+        for (FailEmailModel fail : fails) {
+            try {
+                //이메일 재전송
+                emailService.sendHtmlEmail(fail.getToEmail(), fail.getSubject(), fail.getContent());
+                fail.markResolved();
+            } catch (Exception e) {
+                log.warn("재시도 실패 - id={}, reason={}", fail.getId(), e.getMessage());
+            }
+        }
+        failEmailOutConnector.saveAll(fails); // 일괄 저장
+    }
+}

--- a/domain/notification/core/service/src/main/java/com/example/notification/email/EmailService.java
+++ b/domain/notification/core/service/src/main/java/com/example/notification/email/EmailService.java
@@ -1,5 +1,7 @@
 package com.example.notification.email;
 
+import com.example.notification.model.FailEmailModel;
+import com.example.outbound.email.FailEmailOutConnector;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -11,12 +13,16 @@ import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailService {
 
     private final JavaMailSender mailSender;
+
+    private final FailEmailOutConnector failEmailOutConnector;
 
     @Retryable(
             value = { MessagingException.class, RuntimeException.class }, // 이 예외 터지면 리트라이
@@ -41,7 +47,16 @@ public class EmailService {
     @Recover
     public void recover(MessagingException e, String to, String subject, String htmlContent) {
         log.error("이메일 발송 최종 실패: 수신자={}, 제목={}", to, subject, e);
-        // 여기서 실패한 이메일을 DB 저장하거나 슬랙 알림 보낼 수도 있음
+        FailEmailModel failEmailModel = FailEmailModel
+                .builder()
+                .toEmail(to)
+                .subject(subject)
+                .content(htmlContent)
+                .resolved(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        failEmailOutConnector.createFailEmail(failEmailModel);
     }
 
 }

--- a/domain/notification/infrastructure/rdb/src/main/java/com/example/rdbrepository/FailEmailEntity.java
+++ b/domain/notification/infrastructure/rdb/src/main/java/com/example/rdbrepository/FailEmailEntity.java
@@ -1,0 +1,35 @@
+package com.example.rdbrepository;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FailEmailEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String toEmail;
+    private String subject;
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    private boolean resolved;
+
+    private LocalDateTime createdAt;
+
+    public void markResolved() {
+        this.resolved = true;
+    }
+
+}

--- a/domain/notification/infrastructure/rdb/src/main/java/com/example/rdbrepository/FailEmailEntityRepository.java
+++ b/domain/notification/infrastructure/rdb/src/main/java/com/example/rdbrepository/FailEmailEntityRepository.java
@@ -1,0 +1,11 @@
+package com.example.rdbrepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FailEmailEntityRepository extends JpaRepository<FailEmailEntity,Long> {
+
+    List<FailEmailEntity> findByResolvedFalse();
+    void saveAll(List<FailEmailEntity> failEmails);
+}


### PR DESCRIPTION
- FailEmailModel/Entity 생성 및 매핑 로직 추가
- FailEmailOutConnector 를 작성
- 이메일 재시도용 EmailRetryScheduler 구성 (@Scheduled 기반)
- 이메일 발송 실패 시 @Recover에서 FailEmailModel 저장 처리