### PR TITLE
- feat: 알림 구독 여부 기능

### DIFF
--- a/common/events/src/main/java/com/example/events/enums/ScheduleActionType.java
+++ b/common/events/src/main/java/com/example/events/enums/ScheduleActionType.java
@@ -8,5 +8,6 @@ import lombok.NoArgsConstructor;
 public enum ScheduleActionType {
     SCHEDULE_CREATED,
     SCHEDULE_UPDATE,
-    SCHEDULE_DELETE
+    SCHEDULE_DELETE,
+    SCHEDULE_REMINDER
 }

--- a/common/events/src/main/java/com/example/events/kafka/NotificationEvents.java
+++ b/common/events/src/main/java/com/example/events/kafka/NotificationEvents.java
@@ -27,6 +27,7 @@ public class NotificationEvents {
             case SCHEDULE_CREATED -> "📅 일정이 생성되었습니다: " + events.getContents();
             case SCHEDULE_UPDATE -> "✏️ 일정이 수정되었습니다: " + events.getContents();
             case SCHEDULE_DELETE -> "🗑️ 일정이 삭제되었습니다: " + events.getContents();
+            case SCHEDULE_REMINDER -> "일정 리마인드 알림입니다: " + events.getContents();
         };
 
         return NotificationEvents

--- a/domain/notification/api/api-model/src/main/java/com/example/apimodel/notification/NotificationSettingApiModel.java
+++ b/domain/notification/api/api-model/src/main/java/com/example/apimodel/notification/NotificationSettingApiModel.java
@@ -1,0 +1,26 @@
+package com.example.apimodel.notification;
+
+
+import lombok.Builder;
+
+public class NotificationSettingApiModel {
+
+    @Builder
+    public record NotificationSettingRequest(
+            boolean enabled,
+            String userId
+    ){}
+
+    @Builder
+    public record NotificationSettingResponse(
+            Long id,
+            String userId,
+            boolean scheduleCreatedEnabled,
+            boolean scheduleUpdatedEnabled,
+            boolean scheduleDeletedEnabled,
+            boolean scheduleRemindEnabled,
+            boolean webEnabled,
+            boolean emailEnabled,
+            boolean pushEnabled
+    ){ }
+}

--- a/domain/notification/api/controller/src/main/java/com/example/controller/notification/NotificationSettingController.java
+++ b/domain/notification/api/controller/src/main/java/com/example/controller/notification/NotificationSettingController.java
@@ -1,0 +1,27 @@
+package com.example.controller.notification;
+
+import com.example.apimodel.notification.NotificationSettingApiModel;
+import com.example.inbound.notification.NotificationSettingInConnector;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/notification-setting")
+@AllArgsConstructor
+public class NotificationSettingController {
+
+    private final NotificationSettingInConnector notificationSettingInConnector;
+
+    // 알림 설정 on/off
+    @PutMapping("/me/all")
+    public NotificationSettingApiModel.NotificationSettingResponse updateAllChannelToggle(@RequestBody NotificationSettingApiModel.NotificationSettingRequest request) {
+        return notificationSettingInConnector.updateAllChannels(request.userId(), request.enabled());
+    }
+
+    // 알림설정 초기화
+    @PostMapping("/me/reset")
+    public void resetToDefault(@PathVariable("id")String userId) {
+        notificationSettingInConnector.resetToDefault(userId);
+    }
+
+}

--- a/domain/notification/connector/in-bound/src/main/java/com/example/inbound/notification/NotificationSettingInConnector.java
+++ b/domain/notification/connector/in-bound/src/main/java/com/example/inbound/notification/NotificationSettingInConnector.java
@@ -1,0 +1,41 @@
+package com.example.inbound.notification;
+
+import com.example.apimodel.notification.NotificationSettingApiModel;
+import com.example.interfaces.notification.NotificationSettingInterfaces;
+import com.example.notification.model.NotificationSettingModel;
+import com.example.notification.service.NotificationSettingService;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class NotificationSettingInConnector implements NotificationSettingInterfaces {
+
+    private final NotificationSettingService notificationSettingService;
+
+    @Override
+    public NotificationSettingApiModel.NotificationSettingResponse updateAllChannels(String userId, boolean enabled) {
+        return toModel(notificationSettingService.updateAllChannels(userId,enabled));
+    }
+
+    @Override
+    public void resetToDefault(String userId) {
+        notificationSettingService.resetToDefault(userId);
+    }
+
+    private NotificationSettingApiModel.NotificationSettingResponse toModel(NotificationSettingModel model) {
+        return NotificationSettingApiModel
+                .NotificationSettingResponse
+                .builder()
+                .id(model.getId())
+                .userId(model.getUserId())
+                .webEnabled(model.isWebEnabled())
+                .emailEnabled(model.isEmailEnabled())
+                .pushEnabled(model.isPushEnabled())
+                .scheduleCreatedEnabled(model.isScheduleCreatedEnabled())
+                .scheduleUpdatedEnabled(model.isScheduleUpdatedEnabled())
+                .scheduleDeletedEnabled(model.isScheduleDeletedEnabled())
+                .scheduleRemindEnabled(model.isScheduleRemindEnabled())
+                .build();
+    }
+}

--- a/domain/notification/connector/interfaces/src/main/java/com/example/interfaces/notification/NotificationSettingInterfaces.java
+++ b/domain/notification/connector/interfaces/src/main/java/com/example/interfaces/notification/NotificationSettingInterfaces.java
@@ -1,0 +1,10 @@
+package com.example.interfaces.notification;
+
+import com.example.apimodel.notification.NotificationSettingApiModel;
+
+public interface NotificationSettingInterfaces {
+
+    NotificationSettingApiModel.NotificationSettingResponse updateAllChannels(String userId, boolean enabled);
+
+    void resetToDefault(String userId);
+}

--- a/domain/notification/connector/out-bound/src/main/java/com/example/outbound/notification/NotificationSettingOutConnector.java
+++ b/domain/notification/connector/out-bound/src/main/java/com/example/outbound/notification/NotificationSettingOutConnector.java
@@ -1,0 +1,67 @@
+package com.example.outbound.notification;
+
+import com.example.notification.model.NotificationSettingModel;
+import com.example.rdbrepository.NotificationSetting;
+import com.example.rdbrepository.NotificationSettingRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@AllArgsConstructor
+public class NotificationSettingOutConnector {
+
+    private final NotificationSettingRepository notificationSettingRepository;
+
+    public NotificationSettingModel findByUserId(String userId) {
+        return toModel(notificationSettingRepository
+                .findByUserId(userId)
+                .orElseThrow());
+    }
+
+    public NotificationSettingModel findById(Long id) {
+        return toModel(notificationSettingRepository
+                .findById(id)
+                .orElseThrow());
+    }
+
+    //사용자 알림 설정 조회 또는 생성
+    public NotificationSettingModel getOrCreate(String userId) {
+        return notificationSettingRepository.findByUserId(userId)
+                .map(this::toModel)
+                .orElseGet(() -> {
+                    NotificationSetting newSetting = NotificationSetting.builder()
+                            .userId(userId)
+                            .webEnabled(true)
+                            .emailEnabled(false)
+                            .pushEnabled(false)
+                            .build();
+                    return toModel(notificationSettingRepository.save(newSetting));
+                });
+    }
+
+    //전체 설정 저장
+    public void updateSetting(NotificationSettingModel notificationSettingModel) {
+        notificationSettingRepository.save(toEntity(notificationSettingModel));
+    }
+
+    private NotificationSettingModel toModel(NotificationSetting entity) {
+        return NotificationSettingModel.builder()
+                .id(entity.getId())
+                .userId(entity.getUserId())
+                .webEnabled(entity.isWebEnabled())
+                .emailEnabled(entity.isEmailEnabled())
+                .pushEnabled(entity.isPushEnabled())
+                .build();
+    }
+
+    private NotificationSetting toEntity(NotificationSettingModel model) {
+        return NotificationSetting
+                .builder()
+                .id(model.getId())
+                .userId(model.getUserId())
+                .webEnabled(model.isWebEnabled())
+                .emailEnabled(model.isEmailEnabled())
+                .pushEnabled(model.isPushEnabled())
+                .build();
+    }
+}

--- a/domain/notification/core/model/src/main/java/com/example/notification/model/NotificationSettingModel.java
+++ b/domain/notification/core/model/src/main/java/com/example/notification/model/NotificationSettingModel.java
@@ -1,0 +1,23 @@
+package com.example.notification.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationSettingModel {
+
+    private Long id;
+    private String userId;
+    private boolean scheduleCreatedEnabled;
+    private boolean scheduleUpdatedEnabled;
+    private boolean scheduleDeletedEnabled;
+    private boolean scheduleRemindEnabled;
+    private boolean webEnabled;
+    private boolean emailEnabled;
+    private boolean pushEnabled;
+}

--- a/domain/notification/core/service/src/main/java/com/example/notification/service/NotificationSettingService.java
+++ b/domain/notification/core/service/src/main/java/com/example/notification/service/NotificationSettingService.java
@@ -1,0 +1,64 @@
+package com.example.notification.service;
+
+import com.example.events.enums.NotificationChannel;
+import com.example.events.enums.ScheduleActionType;
+import com.example.notification.model.NotificationSettingModel;
+import com.example.outbound.notification.NotificationSettingOutConnector;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class NotificationSettingService {
+
+    private final NotificationSettingOutConnector notificationSettingOutConnector;
+
+    //알림 발송 여부 판단 (채널 기준만) -> 컨슈머 확인용.
+    public boolean isEnabled(Long userId,NotificationChannel channel) {
+        NotificationSettingModel notificationSettingModel = notificationSettingOutConnector.
+                findById(userId);
+        return isChannelEnabled(notificationSettingModel, channel);
+    }
+
+    //전체 알림 설정 저장
+    public void updateSetting(NotificationSettingModel notificationSettingModel) {
+        notificationSettingOutConnector.updateSetting(notificationSettingModel);
+    }
+
+    public NotificationSettingModel updateAllChannels(String userId, boolean enabled) {
+        NotificationSettingModel current = notificationSettingOutConnector.getOrCreate(userId);
+
+        NotificationSettingModel updated = current
+                .toBuilder()
+                .webEnabled(enabled)
+                .emailEnabled(enabled)
+                .pushEnabled(enabled)
+                .build();
+        notificationSettingOutConnector.updateSetting(updated);
+        return updated;
+    }
+
+    //초기값으로 되돌리기
+    public void resetToDefault(String userId) {
+        NotificationSettingModel defaultSetting = NotificationSettingModel
+                .builder()
+                .userId(userId)
+                .webEnabled(true)
+                .emailEnabled(false)
+                .pushEnabled(false)
+                .build();
+        notificationSettingOutConnector.updateSetting(defaultSetting);
+    }
+
+    public NotificationSettingModel getSetting(String userId) {
+        return notificationSettingOutConnector.getOrCreate(userId);
+    }
+
+    private boolean isChannelEnabled(NotificationSettingModel setting, NotificationChannel channel) {
+        return switch (channel) {
+            case WEB -> setting.isWebEnabled();
+            case EMAIL -> setting.isEmailEnabled();
+            case PUSH -> setting.isPushEnabled();
+        };
+    }
+}

--- a/domain/notification/infrastructure/rdb/src/main/java/com/example/rdbrepository/NotificationSetting.java
+++ b/domain/notification/infrastructure/rdb/src/main/java/com/example/rdbrepository/NotificationSetting.java
@@ -1,0 +1,42 @@
+package com.example.rdbrepository;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationSetting {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String userId;
+
+    @Builder.Default
+    private boolean scheduleCreatedEnabled = true;
+
+    @Builder.Default
+    private boolean scheduleUpdatedEnabled = true;
+
+    @Builder.Default
+    private boolean scheduleDeletedEnabled = true;
+
+    @Builder.Default
+    private boolean scheduleRemindEnabled = true;
+
+    @Builder.Default
+    private boolean webEnabled = true;
+
+    @Builder.Default
+    private boolean emailEnabled = false;
+
+    @Builder.Default
+    private boolean pushEnabled = false;
+}

--- a/domain/notification/infrastructure/rdb/src/main/java/com/example/rdbrepository/NotificationSettingRepository.java
+++ b/domain/notification/infrastructure/rdb/src/main/java/com/example/rdbrepository/NotificationSettingRepository.java
@@ -1,0 +1,10 @@
+package com.example.rdbrepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NotificationSettingRepository extends JpaRepository<NotificationSetting,Long> {
+
+    Optional<NotificationSetting> findByUserId(String userId);
+}


### PR DESCRIPTION
## 주요 변경 사항

- 사용자 알림 설정 엔드포인트 추가
  - `POST /api/notification-settings/me/reset`: 알림 설정 리셋
  - `PUT /api/notification-settings/me/all`: 전체 채널(web, push, email) 일괄 ON/OFF
- NotificationSettingService 리팩토링
  - 알림 발송 여부 확인 로직 단순화
  - 사용자 설정 초기화 기능 `resetToDefault()` 추가
- OutConnector (`NotificationSettingOutConnector`)
  - userId(String) 기반 조회 및 저장 메서드 구성
- 프론트 대응을 위한 API 연동 전제 기반 완료

## 테스트

- Postman을 통해 GET/PUT 요청 정상 동작 확인
- 토큰 기반 인증으로 사용자 식별 처리

## TODO (추후 작업)

- 프론트 알림 설정 토글 연동 및 상태 표현