### PR TITLE
feat: 알림 푸시기능

### DIFF
--- a/bootstrap/src/test/java/com/example/schedules/ScheduleCRUDTest.java
+++ b/bootstrap/src/test/java/com/example/schedules/ScheduleCRUDTest.java
@@ -4,6 +4,7 @@ import com.example.enumerate.schedules.DeleteType;
 import com.example.enumerate.schedules.RepeatType;
 import com.example.enumerate.schedules.RepeatUpdateType;
 import com.example.enumerate.schedules.ScheduleType;
+import com.example.events.enums.NotificationChannel;
 import com.example.events.enums.ScheduleActionType;
 import com.example.model.schedules.SchedulesModel;
 import com.example.outbound.schedule.ScheduleOutConnector;
@@ -24,7 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.access.AccessDeniedException;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -96,7 +96,7 @@ public class ScheduleCRUDTest {
             assertThat(result.getScheduleType()).isEqualTo(ScheduleType.SINGLE_DAY);
             verify(out).validateScheduleConflict(any(SchedulesModel.class));
             verify(out).saveSchedule(any(SchedulesModel.class));
-            verify(events).publishScheduleEvent(saved, ScheduleActionType.SCHEDULE_CREATED);
+            verify(events).publishScheduleEvent(saved, ScheduleActionType.SCHEDULE_CREATED, NotificationChannel.WEB);
             verify(attach, never()).bindToSchedule(anyList(), anyLong()); }
     }
 
@@ -159,7 +159,7 @@ public class ScheduleCRUDTest {
             // 3건 저장 호출 확인
             verify(out, times(3)).saveSchedule(any(SchedulesModel.class));
             // 이벤트 1회(최초 스케줄 기준) 발행 확인
-            verify(events).publishScheduleEvent(firstSaved, ScheduleActionType.SCHEDULE_CREATED);
+            verify(events).publishScheduleEvent(firstSaved, ScheduleActionType.SCHEDULE_CREATED,NotificationChannel.WEB);
         }
     }
 
@@ -191,7 +191,7 @@ public class ScheduleCRUDTest {
             assertThat(saved.getScheduleType()).isEqualTo(ScheduleType.ALL_DAY);
             assertThat(saved.getMemberId()).isEqualTo(777L);
 
-            verify(events).publishScheduleEvent(saved, ScheduleActionType.SCHEDULE_CREATED);
+            verify(events).publishScheduleEvent(saved, ScheduleActionType.SCHEDULE_CREATED,NotificationChannel.WEB);
         }
     }
 
@@ -214,7 +214,7 @@ public class ScheduleCRUDTest {
             // then
             verify(repeatDelete).dispatch(DeleteType.SINGLE, target);
             verify(out).deleteSchedule(10L);
-            verify(events).publishScheduleEvent(target, ScheduleActionType.SCHEDULE_DELETE);
+            verify(events).publishScheduleEvent(target, ScheduleActionType.SCHEDULE_DELETE,NotificationChannel.WEB);
         }
     }
 
@@ -244,7 +244,7 @@ public class ScheduleCRUDTest {
             // then
             verify(repeatDelete).dispatch(DeleteType.ALL_REPEAT, target);
             verify(out).markAsDeletedByRepeatGroupId("RG");
-            verify(events).publishScheduleEvent(target, ScheduleActionType.SCHEDULE_DELETE);
+            verify(events).publishScheduleEvent(target, ScheduleActionType.SCHEDULE_DELETE,NotificationChannel.WEB);
         }
     }
 
@@ -271,7 +271,7 @@ public class ScheduleCRUDTest {
 
             verify(repeatDelete).dispatch(DeleteType.AFTER_THIS, target);
             verify(out).markAsDeletedAfter("GRP", st);
-            verify(events).publishScheduleEvent(target, ScheduleActionType.SCHEDULE_DELETE);
+            verify(events).publishScheduleEvent(target, ScheduleActionType.SCHEDULE_DELETE,NotificationChannel.WEB);
         }
     }
 

--- a/domain/notification/api/api-model/src/main/java/com/example/apimodel/notification/NotificationPushApiModel.java
+++ b/domain/notification/api/api-model/src/main/java/com/example/apimodel/notification/NotificationPushApiModel.java
@@ -1,0 +1,33 @@
+package com.example.apimodel.notification;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public class NotificationPushApiModel {
+
+    @Builder
+    public record NotificationPushRequest(
+            Long memberId,
+            String endpoint,
+            String p256dh,
+            String auth,
+            String userAgent
+    ){}
+
+    @Builder
+    public record NotificationPushResponse(
+            Long id,
+            Long memberId,
+            String endpoint,
+            String p256dh,
+            String auth,
+            Long expirationTime, // millis nullable
+            String userAgent,
+            boolean active,
+            LocalDateTime createdAt,
+            LocalDateTime revokedAt) {
+
+    }
+
+}

--- a/domain/notification/api/api-model/src/main/java/com/example/apimodel/notification/NotificationPushApiModel.java
+++ b/domain/notification/api/api-model/src/main/java/com/example/apimodel/notification/NotificationPushApiModel.java
@@ -1,6 +1,7 @@
 package com.example.apimodel.notification;
 
 import lombok.Builder;
+import org.springframework.cglib.core.Local;
 
 import java.time.LocalDateTime;
 
@@ -22,7 +23,7 @@ public class NotificationPushApiModel {
             String endpoint,
             String p256dh,
             String auth,
-            Long expirationTime, // millis nullable
+            LocalDateTime expirationTime, // millis nullable
             String userAgent,
             boolean active,
             LocalDateTime createdAt,

--- a/domain/notification/api/controller/src/main/java/com/example/controller/notification/NotificationPushController.java
+++ b/domain/notification/api/controller/src/main/java/com/example/controller/notification/NotificationPushController.java
@@ -1,0 +1,43 @@
+package com.example.controller.notification;
+
+import com.example.apimodel.notification.NotificationPushApiModel;
+import com.example.inbound.notification.NotificationPushInConnector;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/push")
+public class NotificationPushController {
+
+    private final NotificationPushInConnector pushInConnector;
+
+    //알림 푸시 구독
+    @PostMapping("/subscribe")
+    public ResponseEntity<NotificationPushApiModel.NotificationPushResponse> subscribe(@RequestBody NotificationPushApiModel.NotificationPushRequest request) {
+        NotificationPushApiModel.NotificationPushResponse model = pushInConnector.subscribe(request);
+        return ResponseEntity.ok(model);
+    }
+
+    //
+    @GetMapping("/active")
+    public ResponseEntity<List<NotificationPushApiModel.NotificationPushResponse>> getActive(@RequestParam Long memberId) {
+        return ResponseEntity.ok(pushInConnector.getActiveSubscriptions(memberId));
+    }
+
+    // 알림 푸시 구독 해제
+    @PostMapping("/unsubscribe")
+    public ResponseEntity<Void> unsubscribe(@RequestParam Long memberId, @RequestParam String endpoint) {
+        pushInConnector.deactivateByEndpoint(memberId, endpoint);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/unsubscribeAll")
+    public ResponseEntity<Void> unsubscribeAll(@RequestParam Long memberId) {
+        pushInConnector.deactivateAll(memberId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/domain/notification/connector/in-bound/src/main/java/com/example/inbound/notification/NotificationPushInConnector.java
+++ b/domain/notification/connector/in-bound/src/main/java/com/example/inbound/notification/NotificationPushInConnector.java
@@ -1,0 +1,63 @@
+package com.example.inbound.notification;
+
+import com.example.apimodel.notification.NotificationPushApiModel;
+import com.example.interfaces.notification.NotificationPushInterfaces;
+import com.example.notification.model.PushSubscriptionModel;
+import com.example.notification.service.PushSubscriptionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationPushInConnector implements NotificationPushInterfaces {
+
+    private final PushSubscriptionService pushSubscriptionService;
+
+    @Override
+    public NotificationPushApiModel.NotificationPushResponse subscribe(NotificationPushApiModel.NotificationPushRequest request) {
+        return toApiModel(pushSubscriptionService
+                .saveSubscription(request.memberId(),
+                        request.endpoint(),
+                        request.p256dh(),
+                        request.auth(),
+                        request.userAgent()));
+    }
+
+    @Override
+    public List<NotificationPushApiModel.NotificationPushResponse> getActiveSubscriptions(Long memberId) {
+        return pushSubscriptionService.getActiveSubscriptions(memberId)
+                .stream()
+                .map(this::toApiModel)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void deactivateAll(Long memberId) {
+        pushSubscriptionService.deactivateAll(memberId);
+    }
+
+    @Override
+    public void deactivateByEndpoint(Long memberId, String endpoint) {
+        pushSubscriptionService.deactivateByEndpoint(memberId, endpoint);
+    }
+
+    private NotificationPushApiModel.NotificationPushResponse toApiModel(PushSubscriptionModel pushSubscriptionModel) {
+        return NotificationPushApiModel.NotificationPushResponse
+                .builder()
+                .id(pushSubscriptionModel.getId())
+                .auth(pushSubscriptionModel.getAuth())
+                .active(pushSubscriptionModel.isActive())
+                .p256dh(pushSubscriptionModel.getP256dh())
+                .endpoint(pushSubscriptionModel.getEndpoint())
+                .userAgent(pushSubscriptionModel.getUserAgent())
+                .memberId(pushSubscriptionModel.getMemberId())
+                .createdAt(pushSubscriptionModel.getCreatedAt())
+                .expirationTime(pushSubscriptionModel.getExpirationTime())
+                .revokedAt(pushSubscriptionModel.getRevokedAt())
+                .build();
+    }
+
+}

--- a/domain/notification/connector/in-bound/src/main/java/com/example/inbound/notification/NotificationSettingInConnector.java
+++ b/domain/notification/connector/in-bound/src/main/java/com/example/inbound/notification/NotificationSettingInConnector.java
@@ -1,6 +1,7 @@
 package com.example.inbound.notification;
 
 import com.example.apimodel.notification.NotificationSettingApiModel;
+import com.example.events.enums.NotificationChannel;
 import com.example.interfaces.notification.NotificationSettingInterfaces;
 import com.example.notification.model.NotificationSettingModel;
 import com.example.notification.service.NotificationSettingService;
@@ -21,6 +22,11 @@ public class NotificationSettingInConnector implements NotificationSettingInterf
     @Override
     public void resetToDefault(Long userId) {
         notificationSettingService.resetToDefault(userId);
+    }
+
+    @Override
+    public boolean isEnabled(Long memberId, NotificationChannel channel) {
+        return notificationSettingService.isEnabled(memberId,channel);
     }
 
     private NotificationSettingApiModel.NotificationSettingResponse toModel(NotificationSettingModel model) {

--- a/domain/notification/connector/interfaces/src/main/java/com/example/interfaces/notification/NotificationPushInterfaces.java
+++ b/domain/notification/connector/interfaces/src/main/java/com/example/interfaces/notification/NotificationPushInterfaces.java
@@ -1,0 +1,17 @@
+package com.example.interfaces.notification;
+
+import com.example.apimodel.notification.NotificationPushApiModel;
+
+import java.util.List;
+
+public interface NotificationPushInterfaces {
+
+    NotificationPushApiModel.NotificationPushResponse subscribe(NotificationPushApiModel.NotificationPushRequest request);
+
+    List<NotificationPushApiModel.NotificationPushResponse> getActiveSubscriptions(Long memberId);
+
+    void deactivateAll(Long memberId);
+
+    void deactivateByEndpoint(Long memberId, String endpoint);
+
+}

--- a/domain/notification/connector/interfaces/src/main/java/com/example/interfaces/notification/NotificationSettingInterfaces.java
+++ b/domain/notification/connector/interfaces/src/main/java/com/example/interfaces/notification/NotificationSettingInterfaces.java
@@ -1,10 +1,13 @@
 package com.example.interfaces.notification;
 
 import com.example.apimodel.notification.NotificationSettingApiModel;
+import com.example.events.enums.NotificationChannel;
 
 public interface NotificationSettingInterfaces {
 
     NotificationSettingApiModel.NotificationSettingResponse updateAllChannels(Long userId, boolean enabled);
 
     void resetToDefault(Long userId);
+
+    boolean isEnabled(Long memberId, NotificationChannel channel);
 }

--- a/domain/notification/connector/out-bound/api-client/src/main/java/com/example/apiclient/config/webpush/WebPushConfig.java
+++ b/domain/notification/connector/out-bound/api-client/src/main/java/com/example/apiclient/config/webpush/WebPushConfig.java
@@ -1,0 +1,35 @@
+package com.example.apiclient.config.webpush;
+
+import jakarta.annotation.PostConstruct;
+import nl.martijndwars.webpush.PushService;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.security.Security;
+
+@Configuration
+public class WebPushConfig {
+
+    @Value("${webpush.vapid.public}")
+    private String publicKey;
+
+    @Value("${webpush.vapid.private}")
+    private String privateKey;
+
+    @Value("${webpush.subject}")
+    private String subject;
+
+    @PostConstruct
+    public void setupProvider() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    @Bean
+    public PushService pushService () throws Exception {
+        return new PushService(publicKey, privateKey, subject);
+    }
+}

--- a/domain/notification/connector/out-bound/src/main/java/com/example/outbound/notification/PushSubscriptionOutConnector.java
+++ b/domain/notification/connector/out-bound/src/main/java/com/example/outbound/notification/PushSubscriptionOutConnector.java
@@ -1,0 +1,79 @@
+package com.example.outbound.notification;
+
+import com.example.notification.model.PushSubscriptionModel;
+import com.example.rdbrepository.PushSubscription;
+import com.example.rdbrepository.PushSubscriptionRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Component
+@AllArgsConstructor
+public class PushSubscriptionOutConnector {
+
+    private final PushSubscriptionRepository pushSubscriptionRepository;
+
+    public List<PushSubscriptionModel> findByMemberIdAndActiveTrue(Long memberId) {
+        return pushSubscriptionRepository
+                .findByMemberIdAndActiveTrue(memberId)
+                .stream()
+                .map(this::toModel)
+                .collect(Collectors.toList());
+    }
+
+    public PushSubscriptionModel savePush(PushSubscriptionModel pushSubscriptionModel) {
+        PushSubscription pushSubscription = PushSubscription
+                .builder()
+                .active(pushSubscriptionModel.isActive())
+                .auth(pushSubscriptionModel.getAuth())
+                .endpoint(pushSubscriptionModel.getEndpoint())
+                .p256dh(pushSubscriptionModel.getP256dh())
+                .userAgent(pushSubscriptionModel.getUserAgent())
+                .memberId(pushSubscriptionModel.getMemberId())
+                .expirationTime(pushSubscriptionModel.getExpirationTime())
+                .createdAt(pushSubscriptionModel.getCreatedAt())
+                .revokedAt(pushSubscriptionModel.getRevokedAt())
+                .build();
+        return toModel(pushSubscriptionRepository.save(pushSubscription));
+    }
+
+    public Optional<PushSubscriptionModel> findByUserIdAndEndpoint(Long memberId, String endpoint) {
+        return pushSubscriptionRepository
+                .findByMemberIdAndActiveTrue(memberId)
+                .stream()
+                .filter(sub -> sub.getEndpoint().equals(endpoint))
+                .map(this::toModel)
+                .findFirst();
+    }
+
+    public void deactivateAll(Long memberId){
+        pushSubscriptionRepository.findByMemberIdAndActiveTrue(memberId)
+                .forEach(PushSubscription::deactivate);
+    }
+
+    public void deactivateByEndpoint(Long memberId, String endpoint) {
+        pushSubscriptionRepository.findByMemberIdAndActiveTrue(memberId)
+                .stream()
+                .filter(s -> s.getEndpoint().equals(endpoint))
+                .forEach(PushSubscription::deactivate);
+    }
+
+    private PushSubscriptionModel toModel(PushSubscription pushSubscription) {
+        return PushSubscriptionModel
+                .builder()
+                .memberId(pushSubscription.getMemberId())
+                .auth(pushSubscription.getAuth())
+                .active(pushSubscription.isActive())
+                .p256dh(pushSubscription.getP256dh())
+                .endpoint(pushSubscription.getEndpoint())
+                .userAgent(pushSubscription.getUserAgent())
+                .createdAt(pushSubscription.getCreatedAt())
+                .expirationTime(pushSubscription.getExpirationTime())
+                .revokedAt(pushSubscription.getRevokedAt())
+                .build();
+    }
+
+}

--- a/domain/notification/core/model/src/main/java/com/example/notification/model/PushSubscriptionModel.java
+++ b/domain/notification/core/model/src/main/java/com/example/notification/model/PushSubscriptionModel.java
@@ -17,7 +17,7 @@ public class PushSubscriptionModel {
     private String endpoint;
     private String p256dh;
     private String auth;
-    private Long expirationTime; // millis nullable
+    private LocalDateTime expirationTime; // millis nullable
     private String userAgent;
     private boolean active;
     private LocalDateTime createdAt;

--- a/domain/notification/core/model/src/main/java/com/example/notification/model/PushSubscriptionModel.java
+++ b/domain/notification/core/model/src/main/java/com/example/notification/model/PushSubscriptionModel.java
@@ -1,0 +1,25 @@
+package com.example.notification.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor
+public class PushSubscriptionModel {
+    private Long id;
+    private Long memberId;
+    private String endpoint;
+    private String p256dh;
+    private String auth;
+    private Long expirationTime; // millis nullable
+    private String userAgent;
+    private boolean active;
+    private LocalDateTime createdAt;
+    private LocalDateTime revokedAt;
+}

--- a/domain/notification/core/service/src/main/java/com/example/notification/service/PushSubscriptionService.java
+++ b/domain/notification/core/service/src/main/java/com/example/notification/service/PushSubscriptionService.java
@@ -1,0 +1,58 @@
+package com.example.notification.service;
+
+import com.example.notification.model.PushSubscriptionModel;
+import com.example.outbound.notification.PushSubscriptionOutConnector;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional
+@AllArgsConstructor
+public class PushSubscriptionService {
+
+    private final PushSubscriptionOutConnector pushSubscriptionOutConnector;
+
+    // 푸시 구독
+    public PushSubscriptionModel saveSubscription(Long userId, String endpoint, String p256dh, String auth, String userAgent) {
+        return pushSubscriptionOutConnector.findByUserIdAndEndpoint(userId, endpoint)
+                .map(existing -> {
+                    existing = existing.toBuilder()
+                            .active(true)
+                            .revokedAt(null)
+                            .build();
+                    return pushSubscriptionOutConnector.savePush(existing);
+                })
+                .orElseGet(() -> {
+                    PushSubscriptionModel subscription = PushSubscriptionModel.builder()
+                            .memberId(userId)
+                            .endpoint(endpoint)
+                            .p256dh(p256dh)
+                            .auth(auth)
+                            .userAgent(userAgent)
+                            .expirationTime(null)
+                            .active(true)
+                            .createdAt(LocalDateTime.now())
+                            .build();
+                    return pushSubscriptionOutConnector.savePush(subscription);
+                });
+    }
+
+    // 웹 푸시 구독 활성
+    public List<PushSubscriptionModel> getActiveSubscriptions(Long memberId) {
+        return pushSubscriptionOutConnector.findByMemberIdAndActiveTrue(memberId);
+    }
+
+    // 웹 푸시 구독 해제
+    public void deactivateAll(Long memberId) {
+        pushSubscriptionOutConnector.deactivateAll(memberId);
+    }
+
+    public void deactivateByEndpoint(Long memberId, String endpoint) {
+        pushSubscriptionOutConnector.deactivateByEndpoint(memberId, endpoint);
+    }
+
+}

--- a/domain/notification/core/service/src/main/java/com/example/notification/service/PushSubscriptionService.java
+++ b/domain/notification/core/service/src/main/java/com/example/notification/service/PushSubscriptionService.java
@@ -42,6 +42,7 @@ public class PushSubscriptionService {
     }
 
     // 웹 푸시 구독 활성
+    @Transactional(readOnly = true)
     public List<PushSubscriptionModel> getActiveSubscriptions(Long memberId) {
         return pushSubscriptionOutConnector.findByMemberIdAndActiveTrue(memberId);
     }

--- a/domain/notification/core/service/src/main/java/com/example/notification/service/WebPushService.java
+++ b/domain/notification/core/service/src/main/java/com/example/notification/service/WebPushService.java
@@ -1,0 +1,55 @@
+package com.example.notification.service;
+
+import com.example.events.kafka.NotificationEvents;
+import com.example.notification.model.PushSubscriptionModel;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nl.martijndwars.webpush.PushService;
+import org.springframework.stereotype.Service;
+
+import nl.martijndwars.webpush.Notification;
+import java.util.List;
+
+@Slf4j
+@Service
+@AllArgsConstructor
+public class WebPushService {
+
+    private final PushSubscriptionService subscriptionService;
+
+    private final PushService pushService;
+
+    private final ObjectMapper objectMapper;
+
+    public void sendPush(Long memberId, NotificationEvents event) {
+        try {
+            List<PushSubscriptionModel> subs = subscriptionService.getActiveSubscriptions(memberId);
+
+            if (subs.isEmpty()) {
+                log.warn("⚠️ No active webpush subscriptions found for memberId={}", memberId);
+                return;
+            }
+
+            String payload = objectMapper.writeValueAsString(event);
+
+            for (PushSubscriptionModel sub : subs) {
+                try {
+                    Notification notification = new Notification(
+                            sub.getEndpoint(),
+                            sub.getP256dh(),
+                            sub.getAuth(),
+                            payload
+                    );
+                    pushService.send(notification);
+                    log.info(" WebPush 발송 성공 - endpoint={}", sub.getEndpoint());
+                } catch (Exception e) {
+                    log.error(" WebPush 발송 실패 - endpoint={}", sub.getEndpoint(), e);
+                }
+            }
+        } catch (Exception e) {
+            log.error("WebPushService error - memberId={}", memberId, e);
+        }
+    }
+
+}

--- a/domain/notification/infrastructure/rdb/src/main/generated/com/example/rdbrepository/QPushSubscription.java
+++ b/domain/notification/infrastructure/rdb/src/main/generated/com/example/rdbrepository/QPushSubscription.java
@@ -1,0 +1,55 @@
+package com.example.rdbrepository;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QPushSubscription is a Querydsl query type for PushSubscription
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPushSubscription extends EntityPathBase<PushSubscription> {
+
+    private static final long serialVersionUID = 1985903420L;
+
+    public static final QPushSubscription pushSubscription = new QPushSubscription("pushSubscription");
+
+    public final BooleanPath active = createBoolean("active");
+
+    public final StringPath auth = createString("auth");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final StringPath endpoint = createString("endpoint");
+
+    public final NumberPath<Long> expirationTime = createNumber("expirationTime", Long.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Long> memberId = createNumber("memberId", Long.class);
+
+    public final StringPath p256dh = createString("p256dh");
+
+    public final DateTimePath<java.time.LocalDateTime> revokedAt = createDateTime("revokedAt", java.time.LocalDateTime.class);
+
+    public final StringPath userAgent = createString("userAgent");
+
+    public QPushSubscription(String variable) {
+        super(PushSubscription.class, forVariable(variable));
+    }
+
+    public QPushSubscription(Path<? extends PushSubscription> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QPushSubscription(PathMetadata metadata) {
+        super(PushSubscription.class, metadata);
+    }
+
+}
+

--- a/domain/notification/infrastructure/rdb/src/main/java/com/example/rdbrepository/PushSubscription.java
+++ b/domain/notification/infrastructure/rdb/src/main/java/com/example/rdbrepository/PushSubscription.java
@@ -30,7 +30,7 @@ public class PushSubscription {
     @Column(nullable = false, length = 255)
     private String auth;
 
-    private Long expirationTime;  // nullable
+    private LocalDateTime expirationTime;  // nullable
 
     private String userAgent;
 

--- a/domain/notification/infrastructure/rdb/src/main/java/com/example/rdbrepository/PushSubscription.java
+++ b/domain/notification/infrastructure/rdb/src/main/java/com/example/rdbrepository/PushSubscription.java
@@ -1,0 +1,48 @@
+package com.example.rdbrepository;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PushSubscription {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId; // 유저 ID (FK)
+
+    @Column(nullable = false, unique = true, length = 1000)
+    private String endpoint;
+
+    @Column(nullable = false, length = 255)
+    private String p256dh;
+
+    @Column(nullable = false, length = 255)
+    private String auth;
+
+    private Long expirationTime;  // nullable
+
+    private String userAgent;
+
+    private boolean active;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime revokedAt;
+
+    public void deactivate() {
+        this.active = false;
+        this.revokedAt = LocalDateTime.now();
+    }
+
+}

--- a/domain/notification/infrastructure/rdb/src/main/java/com/example/rdbrepository/PushSubscriptionRepository.java
+++ b/domain/notification/infrastructure/rdb/src/main/java/com/example/rdbrepository/PushSubscriptionRepository.java
@@ -1,0 +1,11 @@
+package com.example.rdbrepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PushSubscriptionRepository extends JpaRepository<PushSubscription,Long> {
+
+    List<PushSubscription> findByMemberIdAndActiveTrue(Long memberId);
+
+}

--- a/domain/schedules/core/service/src/main/java/com/example/service/schedule/ScheduleDomainService.java
+++ b/domain/schedules/core/service/src/main/java/com/example/service/schedule/ScheduleDomainService.java
@@ -1,6 +1,7 @@
 package com.example.service.schedule;
 
 import com.example.enumerate.schedules.*;
+import com.example.events.enums.NotificationChannel;
 import com.example.events.enums.ScheduleActionType;
 import com.example.exception.schedules.dto.ScheduleErrorCode;
 import com.example.exception.schedules.exception.ScheduleCustomException;
@@ -117,7 +118,9 @@ public class ScheduleDomainService {
         }
         log.info("일정 저장 완료, 이벤트 발행 시도");
         // 이벤트 발행.
-        domainEventPublisher.publishScheduleEvent(firstSchedule,ScheduleActionType.SCHEDULE_CREATED);
+        NotificationChannel channel = domainEventPublisher.resolveChannel(firstSchedule.getMemberId());
+        log.info(channel.toString());
+        domainEventPublisher.publishScheduleEvent(firstSchedule,ScheduleActionType.SCHEDULE_CREATED,channel);
 
         return firstSchedule;
     }
@@ -148,7 +151,8 @@ public class ScheduleDomainService {
         //타입에 따른 일정 삭제
         repeatDeleteRegistry.dispatch(deleteType,target);
         //삭제후 이벤트 발행.
-        domainEventPublisher.publishScheduleEvent(target, ScheduleActionType.SCHEDULE_DELETE);
+        NotificationChannel channel = domainEventPublisher.resolveChannel(target.getMemberId());
+        domainEventPublisher.publishScheduleEvent(target, ScheduleActionType.SCHEDULE_DELETE,channel);
     }
 
     //선택 삭제
@@ -167,7 +171,8 @@ public class ScheduleDomainService {
         // 각 일정마다 이벤트 발행
         for (Long id : ids) {
             SchedulesModel model = scheduleOutConnector.findById(id); // 이벤트 정보용
-            domainEventPublisher.publishScheduleEvent(model,ScheduleActionType.SCHEDULE_DELETE);
+            NotificationChannel channel = domainEventPublisher.resolveChannel(model.getMemberId());
+            domainEventPublisher.publishScheduleEvent(model,ScheduleActionType.SCHEDULE_DELETE,channel);
         }
     }
 

--- a/domain/schedules/core/service/src/main/java/com/example/service/schedule/repeat/update/AfterThisUpdateHandler.java
+++ b/domain/schedules/core/service/src/main/java/com/example/service/schedule/repeat/update/AfterThisUpdateHandler.java
@@ -1,6 +1,7 @@
 package com.example.service.schedule.repeat.update;
 
 import com.example.enumerate.schedules.RepeatUpdateType;
+import com.example.events.enums.NotificationChannel;
 import com.example.events.enums.ScheduleActionType;
 import com.example.model.schedules.SchedulesModel;
 import com.example.outbound.schedule.ScheduleOutConnector;
@@ -46,7 +47,8 @@ public class AfterThisUpdateHandler implements RepeatUpdateHandler {
             updated = attachBinder.handleAttachUpdate(target, updated);
             updated.updateProgressStatus();
             out.updateSchedule(target.getId(), updated);
-            events.publishScheduleEvent(updated, ScheduleActionType.SCHEDULE_UPDATE);
+            NotificationChannel channel = events.resolveChannel(updated.getMemberId());
+            events.publishScheduleEvent(updated, ScheduleActionType.SCHEDULE_UPDATE,channel);
         });
 
         return out.findById(existing.getId());

--- a/domain/schedules/core/service/src/main/java/com/example/service/schedule/repeat/update/AllRepeatUpdateHandler.java
+++ b/domain/schedules/core/service/src/main/java/com/example/service/schedule/repeat/update/AllRepeatUpdateHandler.java
@@ -1,6 +1,7 @@
 package com.example.service.schedule.repeat.update;
 
 import com.example.enumerate.schedules.RepeatUpdateType;
+import com.example.events.enums.NotificationChannel;
 import com.example.events.enums.ScheduleActionType;
 import com.example.model.schedules.SchedulesModel;
 import com.example.outbound.schedule.ScheduleOutConnector;
@@ -26,7 +27,7 @@ public class AllRepeatUpdateHandler implements RepeatUpdateHandler{
 
     @Override
     public RepeatUpdateType type() {
-        return RepeatUpdateType.AFTER_THIS;
+        return RepeatUpdateType.ALL;
     }
 
     @Override
@@ -46,7 +47,8 @@ public class AllRepeatUpdateHandler implements RepeatUpdateHandler{
             updated = attachBinder.handleAttachUpdate(target, updated);
             updated.updateProgressStatus();
             out.updateSchedule(target.getId(), updated);
-            events.publishScheduleEvent(updated, ScheduleActionType.SCHEDULE_UPDATE);
+            NotificationChannel channel = events.resolveChannel(updated.getMemberId());
+            events.publishScheduleEvent(updated, ScheduleActionType.SCHEDULE_UPDATE,channel);
         });
         return null;
     }

--- a/domain/schedules/core/service/src/main/java/com/example/service/schedule/repeat/update/SingleUpdateHandler.java
+++ b/domain/schedules/core/service/src/main/java/com/example/service/schedule/repeat/update/SingleUpdateHandler.java
@@ -1,6 +1,7 @@
 package com.example.service.schedule.repeat.update;
 
 import com.example.enumerate.schedules.RepeatUpdateType;
+import com.example.events.enums.NotificationChannel;
 import com.example.events.enums.ScheduleActionType;
 import com.example.model.schedules.SchedulesModel;
 import com.example.outbound.schedule.ScheduleOutConnector;
@@ -34,7 +35,8 @@ public class SingleUpdateHandler implements RepeatUpdateHandler {
         updated = attachBinder.handleAttachUpdate(existing,updated);
         updated.updateProgressStatus();
         SchedulesModel result = scheduleOutConnector.updateSchedule(existing.getId(), updated);
-        domainEventPublisher.publishScheduleEvent(result, ScheduleActionType.SCHEDULE_UPDATE);
+        NotificationChannel channel = domainEventPublisher.resolveChannel(updated.getMemberId());
+        domainEventPublisher.publishScheduleEvent(result, ScheduleActionType.SCHEDULE_UPDATE,channel);
         return null;
     }
 

--- a/domain/schedules/core/service/src/main/java/com/example/service/schedule/support/DomainEventPublisher.java
+++ b/domain/schedules/core/service/src/main/java/com/example/service/schedule/support/DomainEventPublisher.java
@@ -3,29 +3,50 @@ package com.example.service.schedule.support;
 import com.example.events.enums.NotificationChannel;
 import com.example.events.enums.ScheduleActionType;
 import com.example.events.spring.ScheduleEvents;
+import com.example.inbound.notification.NotificationSettingInConnector;
 import com.example.model.schedules.SchedulesModel;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DomainEventPublisher {
 
     private final ApplicationEventPublisher applicationEventPublisher;
 
-    public void publishScheduleEvent(SchedulesModel model, ScheduleActionType actionType) {
+    private final NotificationSettingInConnector notificationSettingInConnector;
+
+
+    public void publishScheduleEvent(SchedulesModel model, ScheduleActionType actionType, NotificationChannel channel) {
         ScheduleEvents event = ScheduleEvents.builder()
                 .scheduleId(model.getId())
                 .userId(model.getMemberId())
                 .contents(model.getContents())
+                .startTime(model.getStartTime())
                 .notificationType(actionType)
-                .notificationChannel(NotificationChannel.WEB)
+                .notificationChannel(channel)
                 .createdTime(LocalDateTime.now())
                 .build();
         applicationEventPublisher.publishEvent(event);
+    }
+
+    public NotificationChannel resolveChannel(Long userId) {
+        boolean webEnabled = notificationSettingInConnector.isEnabled(userId, NotificationChannel.WEB);
+        log.info("webAlarm::"+webEnabled);
+        boolean pushEnabled = notificationSettingInConnector.isEnabled(userId, NotificationChannel.PUSH);
+        log.info("pushAlarm::"+pushEnabled);
+        if (pushEnabled) {
+            return NotificationChannel.PUSH; // PUSH 우선
+        } else if (webEnabled) {
+            return NotificationChannel.WEB;
+        } else {
+            return NotificationChannel.WEB; // 기본값
+        }
     }
 
 }

--- a/domain/schedules/infrastructure/rdb/src/main/java/com/example/rdbrepository/Schedules.java
+++ b/domain/schedules/infrastructure/rdb/src/main/java/com/example/rdbrepository/Schedules.java
@@ -17,11 +17,11 @@ import java.time.LocalDateTime;
         name = "schedules",
         indexes = {
                 // 일정 충돌 인덱스
-                @Index(name = "idx_schedules_user_time", columnList = "userId, startTime, endTime"),
+                @Index(name = "idx_schedules_user_time", columnList = "memberId, startTime, endTime"),
                 // [반복/그룹 조작] repeat_group_id + user_id (+ start_time >= ?)
-                @Index(name = "idx_sched_group_user_start", columnList = "repeat_group_id, user_id, start_time"),
+                @Index(name = "idx_sched_group_user_start", columnList = "repeatGroupId, memberId, startTime"),
                 // [상태별 조회]
-                @Index(name = "idx_sched_user_status", columnList = "user_id, progress_status")
+                @Index(name = "idx_sched_user_status", columnList = "memberId, progressStatus")
         }
 )
 @NoArgsConstructor


### PR DESCRIPTION
- DomainEventPublisher.resolveChannel 로직 개선
  - 사용자 설정에 따라 WEB, PUSH 중 단일 채널만 선택되도록 보완
  - (우선순위: PUSH > WEB) 정책 반영
- NotificationEventConsumer에서 channel 분기 명확화
  - WEB: DB 저장 후 WebSocket 전송
  - PUSH: DB 저장 후 WebPushService 발송

-------

피드백 수정 반영

- expirationTime 단위 모호성 제거 (Long → LocalDateTime)
- objectMapper 직렬화와 구독자별 발송 단위로 try-catch 범위 축소