### PR TITLE
feat: 멱등성 로직 구현 및 통합 테스트 추가

### DIFF
--- a/bootstrap/src/main/resources/db/migration/V1__baseline.sql
+++ b/bootstrap/src/main/resources/db/migration/V1__baseline.sql
@@ -111,14 +111,15 @@ CREATE TABLE IF NOT EXISTS failed_message (
  id BIGINT AUTO_INCREMENT PRIMARY KEY,
  topic VARCHAR(255),
  message_type VARCHAR(255),
- payload VARCHAR(2000) UNIQUE,
+ payload VARCHAR(2000),
  retry_count INT,
  resolved BOOLEAN DEFAULT FALSE,
  dead BOOLEAN DEFAULT FALSE,
  exception_message VARCHAR(2000),
  last_tried_at TIMESTAMP,
  resolved_at TIMESTAMP,
- created_at TIMESTAMP
+ created_at TIMESTAMP,
+ UNIQUE KEY uk_failed_message_payload (payload(255))
 );
 
 -- ===================== FAILED_THUMBNAIL =====================

--- a/bootstrap/src/main/resources/logback-spring.xml
+++ b/bootstrap/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
     <!-- 콘솔 출력용 Appender 정의 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg [eventId=%X{eventId}, requestId=%X{requestId}] %n</pattern>
         </encoder>
     </appender>
     <!-- Json 파일 로깅용-->
@@ -26,6 +26,7 @@
                         "thread": "%thread",
                         "logger": "%logger",
                         "message": "%message",
+                        "eventId": "%X{eventId}",
                         "requestId": "%X{requestId}"
                         }
                     </pattern>

--- a/bootstrap/src/test/java/com/example/kafka/KafkaIntegrationTest.java
+++ b/bootstrap/src/test/java/com/example/kafka/KafkaIntegrationTest.java
@@ -10,9 +10,11 @@ import com.example.events.kafka.NotificationEvents;
 import com.example.events.outbox.OutboxEventPublisher;
 import com.example.events.outbox.OutboxEventRepository;
 import com.example.events.outbox.OutboxEventService;
-import com.example.inbound.consumer.member.MemberSignUpDlqRetryScheduler;
-import com.example.inbound.consumer.schedule.NotificationDlqRetryScheduler;
+import com.example.events.process.ProcessedEventRepository;
+import com.example.events.process.ProcessedEventService;
 import com.example.kafka.dlq.DlqTestConsumer;
+import com.example.kafka.dlq.MemberSignUpDlqRetrySchedulerTest;
+import com.example.kafka.dlq.NotificationDlqRetrySchedulerTest;
 import com.example.model.member.MemberModel;
 import com.example.notification.model.NotificationSettingModel;
 import com.example.notification.service.FailedMessageService;
@@ -20,8 +22,6 @@ import com.example.notification.service.NotificationService;
 import com.example.notification.service.NotificationSettingService;
 import com.example.notification.NotificationType;
 import com.example.notification.model.NotificationModel;
-import com.example.notification.service.FailedMessageService;
-import com.example.notification.service.NotificationService;
 import com.example.notification.service.ReminderNotificationService;
 import com.example.outbound.notification.NotificationOutConnector;
 import com.example.service.member.MemberService;
@@ -43,13 +43,16 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.*;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.util.backoff.FixedBackOff;
@@ -63,13 +66,14 @@ import org.testcontainers.utility.DockerImageName;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Import(KafkaIntegrationTest.KafkaTestConfig.class)
+@ContextConfiguration(classes = {KafkaIntegrationTest.KafkaTestConfig.class})
 @Testcontainers
 public class KafkaIntegrationTest {
 
@@ -96,9 +100,11 @@ public class KafkaIntegrationTest {
         registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
     }
 
+    @Qualifier("testMemberKafkaTemplate")
     @Autowired
     KafkaTemplate<String, MemberSignUpKafkaEvent> kafkaTemplate;
 
+    @Qualifier("testNotificationKafkaTemplate")
     @Autowired
     KafkaTemplate<String, NotificationEvents> scheduleTemplate;
 
@@ -136,13 +142,19 @@ public class KafkaIntegrationTest {
     DlqTestConsumer dlqTestConsumer;
 
     @Autowired
-    MemberSignUpDlqRetryScheduler retryScheduler;
+    NotificationDlqRetrySchedulerTest notificationDlqRetryScheduler;
 
     @Autowired
-    NotificationDlqRetryScheduler notificationDlqRetryScheduler;
+    MemberSignUpDlqRetrySchedulerTest retryScheduler;
 
     @Autowired
     FailedMessageService failedMessageService;
+
+    @Autowired
+    ProcessedEventService processedEventService;
+
+    @Autowired
+    ProcessedEventRepository processedEventRepository;
 
     @TestConfiguration
     static class KafkaTestConfig {
@@ -153,12 +165,12 @@ public class KafkaIntegrationTest {
             Map<String, Object> config = new HashMap<>();
             config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
             config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-            config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, org.springframework.kafka.support.serializer.JsonSerializer.class);
-            config.put(org.springframework.kafka.support.serializer.JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+            config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+            config.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
             return new DefaultKafkaProducerFactory<>(config);
         }
 
-        @Bean
+        @Bean(name = "testMemberKafkaTemplate")
         @Primary
         public KafkaTemplate<String, MemberSignUpKafkaEvent> memberKafkaTemplate(
                 ProducerFactory<String, MemberSignUpKafkaEvent> pf) {
@@ -166,14 +178,14 @@ public class KafkaIntegrationTest {
         }
 
         @Bean
-        public DefaultErrorHandler errorHandler(KafkaTemplate<String,MemberSignUpKafkaEvent> template) {
+        public DefaultErrorHandler errorHandler(@Qualifier("testMemberKafkaTemplate") KafkaTemplate<String,MemberSignUpKafkaEvent> template) {
             var recovered = new DeadLetterPublishingRecoverer(template,
                     (record, ex) -> new TopicPartition(record.topic() + ".DLQ", record.partition()));
             var backoff = new FixedBackOff(1000L, 1); // 즉시 재시도 1회
             return new DefaultErrorHandler(recovered, backoff);
         }
 
-        @Bean(name = "memberKafkaListenerFactory")
+        @Bean(name = "testMemberKafkaListenerFactory")
         @Primary
         public ConcurrentKafkaListenerContainerFactory<String, MemberSignUpKafkaEvent> memberKafkaListenerFactory() {
             Map<String, Object> props = new HashMap<>();
@@ -204,12 +216,12 @@ public class KafkaIntegrationTest {
             Map<String, Object> config = new HashMap<>();
             config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
             config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-            config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, org.springframework.kafka.support.serializer.JsonSerializer.class);
-            config.put(org.springframework.kafka.support.serializer.JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+            config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+            config.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
             return new DefaultKafkaProducerFactory<>(config);
         }
 
-        @Bean
+        @Bean(name = "testNotificationKafkaTemplate")
         public KafkaTemplate<String,NotificationEvents> notificationKafkaTemplate(
                 @Qualifier("notificationEventsProducerFactory")
                 ProducerFactory<String,NotificationEvents> pf) {
@@ -217,14 +229,14 @@ public class KafkaIntegrationTest {
         }
 
         @Bean
-        public DefaultErrorHandler notificationErrorHandler(KafkaTemplate<String, NotificationEvents> template) {
-            var recoverer = new DeadLetterPublishingRecoverer(template,
+        public DefaultErrorHandler notificationErrorHandler(@Qualifier("testNotificationKafkaTemplate") KafkaTemplate<String, NotificationEvents> template) {
+            var recover = new DeadLetterPublishingRecoverer(template,
                     (record, ex) -> new TopicPartition(record.topic() + ".DLQ", record.partition()));
             var backoff = new FixedBackOff(1000L, 1);
-            return new DefaultErrorHandler(recoverer, backoff);
+            return new DefaultErrorHandler(recover, backoff);
         }
 
-        @Bean(name = "notificationKafkaListenerFactory")
+        @Bean(name = "testNotificationKafkaListenerFactory")
         public ConcurrentKafkaListenerContainerFactory<String, NotificationEvents> notificationKafkaListenerFactory() {
             Map<String, Object> props = new HashMap<>();
             props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
@@ -245,6 +257,17 @@ public class KafkaIntegrationTest {
             factory.setConsumerFactory(cf);
             factory.setCommonErrorHandler(notificationErrorHandler(notificationKafkaTemplate(notificationEventsProducerFactory())));
             return factory;
+        }
+
+        // outbox 전용.
+        @Bean(name = "testObjectKafkaTemplate")
+        public KafkaTemplate<String, Object> objectKafkaTemplate() {
+            Map<String, Object> config = new HashMap<>();
+            config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+            config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+            config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+            config.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, true); // Outbox 이벤트 직렬화 위해 필요
+            return new KafkaTemplate<>(new DefaultKafkaProducerFactory<>(config));
         }
     }
 
@@ -455,10 +478,13 @@ public class KafkaIntegrationTest {
         outboxEventPublisher.publishOutboxEvents();
 
         // 4. Outbox 상태 확인
-        var events = outboxEventRepository.findAll();
-        assertThat(events).isNotEmpty();
-        assertThat(events.get(0).getSent()).isTrue();
-        assertThat(events.get(0).getSentAt()).isNotNull();
+        await().atMost(10, TimeUnit.SECONDS)
+                .pollInterval(200, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    var events = outboxEventRepository.findAll();
+                    assertThat(events).isNotEmpty();
+                    assertThat(events.get(0).getSent()).isTrue();
+                });
 
         // 5. 알림 저장 확인
         await().atMost(15, TimeUnit.SECONDS)
@@ -494,10 +520,14 @@ public class KafkaIntegrationTest {
         outboxEventPublisher.publishOutboxEvents();
 
         // 4. Outbox 상태 확인
-        var events = outboxEventRepository.findAll();
-        assertThat(events).isNotEmpty();
-        assertThat(events.get(0).getSent()).isTrue();
-        assertThat(events.get(0).getSentAt()).isNotNull();
+        await().atMost(10,TimeUnit.SECONDS)
+                .pollInterval(300, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    var events = outboxEventRepository.findAll();
+                    assertThat(events).isNotEmpty();
+                    assertThat(events.get(0).getSent()).isTrue();
+                    assertThat(events.get(0).getSentAt()).isNotNull();
+                });
 
         // 5. 알림 저장 확인
         await().atMost(10, TimeUnit.SECONDS)
@@ -517,7 +547,7 @@ public class KafkaIntegrationTest {
 
         // 알림 설정을 false로 강제로 저장 (WEB 비활성화)
         notificationSettingService.updateSetting(NotificationSettingModel.builder()
-                .id(userId)
+                .userId(userId)
                 .webEnabled(false)
                 .emailEnabled(false)
                 .pushEnabled(false)
@@ -571,10 +601,14 @@ public class KafkaIntegrationTest {
         outboxEventPublisher.publishOutboxEvents();
 
         // 4. Outbox 상태 확인
-        var events = outboxEventRepository.findAll();
-        assertThat(events).isNotEmpty();
-        assertThat(events.get(0).getSent()).isTrue();
-        assertThat(events.get(0).getSentAt()).isNotNull();
+        await().atMost(10,TimeUnit.SECONDS)
+                .pollInterval(300, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    var events = outboxEventRepository.findAll();
+                    assertThat(events).isNotEmpty();
+                    assertThat(events.get(0).getSent()).isTrue();
+                    assertThat(events.get(0).getSentAt()).isNotNull();
+                });
 
         // 5. Consumer 발송 결과로 알림 저장이 되어있는지 확인
         await().atMost(15, TimeUnit.SECONDS)
@@ -632,10 +666,82 @@ public class KafkaIntegrationTest {
                             .findFirst()
                             .orElseThrow();
 
-                    System.out.println(resultList.stream().collect(Collectors.toList()));
                     boolean sentWrongly = resultList.stream()
                             .anyMatch(n -> n.getMessage().contains("❌") && n.isSent());
                     assertThat(sentWrongly).isFalse();
                 });
     }
+
+    @Test
+    @DisplayName("NotificationEvents 중복 이벤트는 무시되어야 한다")
+    void notificationEventsDuplicateEventShouldBeIgnored() {
+        String eventId = UUID.randomUUID().toString();
+
+        NotificationEvents event1 = NotificationEvents.builder()
+                .eventId(eventId)
+                .receiverId(1000L)
+                .message("중복 이벤트 테스트")
+                .notificationType(ScheduleActionType.SCHEDULE_CREATED)
+                .notificationChannel(NotificationChannel.WEB)
+                .createdTime(LocalDateTime.now())
+                .build();
+
+        NotificationEvents event2 = NotificationEvents.builder()
+                .eventId(eventId) // 같은 eventId
+                .receiverId(1000L)
+                .message("중복 이벤트 테스트")
+                .notificationType(ScheduleActionType.SCHEDULE_CREATED)
+                .notificationChannel(NotificationChannel.WEB)
+                .createdTime(LocalDateTime.now())
+                .build();
+
+        // 동일 이벤트 2번 발행
+        scheduleTemplate.send("notification-events", event1);
+        scheduleTemplate.send("notification-events", event2);
+
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    var result = notificationService.getNotificationsByUserId(1000L);
+                    assertThat(result).hasSize(1); // 중복 저장 금지
+                    assertThat(result.get(0).getMessage()).contains("중복 이벤트 테스트");
+                });
+    }
+
+    @Test
+    @DisplayName("MemberSignUp 이벤트 중복은 무시되어야 한다")
+    void memberSignUpDuplicateEventShouldBeIgnored() {
+        String eventId = UUID.randomUUID().toString();
+
+        MemberSignUpKafkaEvent event1 = MemberSignUpKafkaEvent.builder()
+                .eventId(eventId)
+                .receiverId(2000L)
+                .username("dupUser")
+                .email("dup@test.com")
+                .message("🎉 환영합니다, dupUser님! 회원가입이 완료되었습니다.")
+                .notificationType("SIGN_UP")
+                .createdTime(LocalDateTime.now())
+                .build();
+
+        MemberSignUpKafkaEvent event2 = MemberSignUpKafkaEvent.builder()
+                .eventId(eventId)
+                .receiverId(2000L)
+                .username("dupUser")
+                .email("dup@test.com")
+                .message("🎉 환영합니다, dupUser님! 회원가입이 완료되었습니다.")
+                .notificationType("SIGN_UP")
+                .createdTime(LocalDateTime.now())
+                .build();
+
+        kafkaTemplate.send("member-signup-events", event1);
+        kafkaTemplate.send("member-signup-events", event2);
+
+        await().atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    var result = notificationService.getNotificationsByUserId(2000L);
+                    assertThat(result).hasSize(1); // 중복 insert 차단
+                    assertThat(result.get(0).getMessage()).contains("🎉 환영합니다, dupUser님! 회원가입이 완료되었습니다.");
+                });
+    }
+
+
 }

--- a/bootstrap/src/test/java/com/example/kafka/dlq/DlqTestConsumer.java
+++ b/bootstrap/src/test/java/com/example/kafka/dlq/DlqTestConsumer.java
@@ -6,6 +6,7 @@ import com.example.notification.model.FailMessageModel;
 import com.example.notification.service.FailedMessageService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
+import org.springframework.boot.test.context.TestComponent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -29,7 +30,7 @@ public class DlqTestConsumer {
 
     @KafkaListener(topics = "member-signup-events.DLQ",
             groupId ="test-member-signup-group",
-            containerFactory = "memberKafkaListenerFactory")
+            containerFactory = "testMemberKafkaListenerFactory")
     public void consumeDlq(MemberSignUpKafkaEvent event) {
 
         MemberDlqMessages.add(event);
@@ -56,7 +57,7 @@ public class DlqTestConsumer {
 
     @KafkaListener(topics = "notification-events.DLQ",
             groupId = "test-notification-group",
-            containerFactory = "notificationKafkaListenerFactory")
+            containerFactory = "testNotificationKafkaListenerFactory")
     public void consumeDlq(NotificationEvents event) {
 
         NotificationDlqMessage.add(event);

--- a/bootstrap/src/test/java/com/example/kafka/dlq/TestFailingConsumer.java
+++ b/bootstrap/src/test/java/com/example/kafka/dlq/TestFailingConsumer.java
@@ -3,6 +3,7 @@ package com.example.kafka.dlq;
 import com.example.events.kafka.MemberSignUpKafkaEvent;
 import com.example.events.kafka.NotificationEvents;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.test.context.TestComponent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -13,7 +14,7 @@ import org.springframework.stereotype.Component;
 public class TestFailingConsumer {
 
     // 회원 가입 실패시 사용되는 리스너
-    @KafkaListener(topics = "member-signup-events", containerFactory = "memberKafkaListenerFactory")
+    @KafkaListener(topics = "member-signup-events", containerFactory = "testMemberKafkaListenerFactory")
     public void consume(MemberSignUpKafkaEvent event) {
         if ("강제실패 알림".equals(event.getMessage())) {
             log.info("[TestFailingConsumer] 테스트 메시지 감지됨. 강제 실패 유도!");
@@ -22,7 +23,7 @@ public class TestFailingConsumer {
     }
 
     //일정 CRUD 실패시에 사용되는 리스너
-    @KafkaListener(topics = "notification-events", containerFactory = "notificationKafkaListenerFactory")
+    @KafkaListener(topics = "notification-events", containerFactory = "testNotificationKafkaListenerFactory")
     public void consume(NotificationEvents events) {
         if ("강제실패 알림".equals(events.getMessage())) {
             log.info("[TestFailingConsumer] 테스트 메시지 감지됨. 강제 실패 유도!");

--- a/common/events/src/main/java/com/example/events/kafka/MemberSignUpKafkaEvent.java
+++ b/common/events/src/main/java/com/example/events/kafka/MemberSignUpKafkaEvent.java
@@ -10,11 +10,16 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class MemberSignUpKafkaEvent {
     private Long receiverId;
+    private String eventId;
     private String username;
     private String email;
     private String message;
     private String notificationType;
     private LocalDateTime createdTime;
+
+    public void setEventId(String eventId) {
+        this.eventId = eventId;
+    }
 
     public static MemberSignUpKafkaEvent of(Long receiverId, String username, String email) {
         return MemberSignUpKafkaEvent

--- a/common/events/src/main/java/com/example/events/kafka/NotificationEvents.java
+++ b/common/events/src/main/java/com/example/events/kafka/NotificationEvents.java
@@ -13,14 +13,19 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class NotificationEvents {
-    private Long receiverId;
-    private Long scheduleId;
+    private Long receiverId; // memberId 회원 번호
+    private Long scheduleId; //일정 번호
+    private String eventId; // outbox 의 pk
     private String message;
     private ScheduleActionType notificationType;
     private NotificationChannel notificationChannel;
     private boolean forceSend; // dlq 적용시 강제 적용.
     private LocalDateTime scheduleAt;
     private LocalDateTime createdTime;
+
+    public void setEventId(String eventId) {
+        this.eventId = eventId;
+    }
 
     public void setForceSend(boolean forceSend) {
         this.forceSend = forceSend;

--- a/common/events/src/main/java/com/example/events/process/ProcessedEventEntity.java
+++ b/common/events/src/main/java/com/example/events/process/ProcessedEventEntity.java
@@ -1,0 +1,31 @@
+package com.example.events.process;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(
+        name = "processed_event",
+        indexes = {
+                @Index(name = "idx_event_id", columnList = "eventId", unique = true)
+        }
+)
+public class ProcessedEventEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String eventId; // Outbox PK or 비즈니스 키
+
+    @Column(nullable = false)
+    private LocalDateTime processedAt;
+
+}

--- a/common/events/src/main/java/com/example/events/process/ProcessedEventRepository.java
+++ b/common/events/src/main/java/com/example/events/process/ProcessedEventRepository.java
@@ -1,0 +1,8 @@
+package com.example.events.process;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProcessedEventRepository extends JpaRepository<ProcessedEventEntity,Long> {
+    // 중복 로직 확인
+    boolean existsByEventId(String eventId);
+}

--- a/common/events/src/main/java/com/example/events/process/ProcessedEventService.java
+++ b/common/events/src/main/java/com/example/events/process/ProcessedEventService.java
@@ -1,0 +1,37 @@
+package com.example.events.process;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@Transactional
+@AllArgsConstructor
+public class ProcessedEventService {
+
+    private final ProcessedEventRepository processedEventRepository;
+
+
+    @Transactional(readOnly = true)
+    public boolean isAlreadyProcessed(String eventId) {
+        return processedEventRepository.existsByEventId(eventId);
+    }
+
+    public void saveProcessedEvent(String eventId) {
+        try {
+            ProcessedEventEntity entity = ProcessedEventEntity.builder()
+                    .eventId(eventId)
+                    .processedAt(LocalDateTime.now())
+                    .build();
+            processedEventRepository.save(entity);
+        } catch (DataIntegrityViolationException e) {
+            // 이미 처리된 이벤트라면 무시
+            log.warn("이벤트 중복 저장 시도 감지됨: {}", eventId);
+        }
+    }
+}

--- a/common/exception/src/main/java/com/example/exception/dto/ErrorCode.java
+++ b/common/exception/src/main/java/com/example/exception/dto/ErrorCode.java
@@ -10,7 +10,11 @@ public enum ErrorCode {
     INVALID_PARAMETER(4001, "파라미터 값을 확인해주세요."),
     NOT_FOUND(4002, "존재하않습니다."),
     INTERNAL_SERVER_ERROR(5000, "서버 에러입니다. 서버 팀에 연락주세요!"),
-    DB_ERROR(4003,"데이터베이스에 문제가 발생했습니다.");
+    DB_ERROR(4003,"데이터베이스에 문제가 발생했습니다."),
+    // --- Kafka Event 전용 ---
+    EVENT_DUPLICATE(4100, "이미 처리된 이벤트입니다."),
+    EVENT_SERIALIZATION_ERROR(4101, "이벤트 직렬화/역직렬화에 실패했습니다."),
+    EVENT_PROCESSING_ERROR(4102, "이벤트 처리 중 알 수 없는 오류가 발생했습니다.");
 
     private final int status;
 

--- a/common/logging/src/main/java/com/example/logging/MDC/KafkaMDCUtil.java
+++ b/common/logging/src/main/java/com/example/logging/MDC/KafkaMDCUtil.java
@@ -13,6 +13,8 @@ public class KafkaMDCUtil {
             MDC.put("receiverId", String.valueOf(event.getReceiverId()));
         if (event.getNotificationType() != null)
             MDC.put("notificationType", event.getNotificationType().name());
+        if (event.getEventId() != null)
+            MDC.put("eventId", event.getEventId());
         MDC.put("requestId", UUID.randomUUID().toString());
     }
 
@@ -21,6 +23,8 @@ public class KafkaMDCUtil {
             MDC.put("receiverId", String.valueOf(event.getReceiverId()));
         if (event.getEmail() != null)
             MDC.put("email", event.getEmail());
+        if (event.getEventId() != null)
+            MDC.put("eventId", event.getEventId());
         MDC.put("requestId", UUID.randomUUID().toString());
     }
 

--- a/domain/attach/core/service/src/main/java/com/example/service/attach/ThumbnailService.java
+++ b/domain/attach/core/service/src/main/java/com/example/service/attach/ThumbnailService.java
@@ -27,7 +27,7 @@ import java.io.InputStream;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
-@Service
+@Service("attachFailedThumbnailService")
 @Transactional
 @RequiredArgsConstructor
 public class ThumbnailService {

--- a/domain/attach/core/service/src/main/java/com/example/service/failthumbnail/FailedThumbnailService.java
+++ b/domain/attach/core/service/src/main/java/com/example/service/failthumbnail/FailedThumbnailService.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-@Service
+@Service("failThumbnailService")
 @Transactional
 @AllArgsConstructor
 public class FailedThumbnailService {

--- a/domain/notification/connector/in-bound/build.gradle
+++ b/domain/notification/connector/in-bound/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation project(':common:redis')
     implementation project(':common:events')
     implementation project(':common:logging')
+    implementation project(':common:exception')
     implementation project(':domain:schedules:core:model')
     implementation project(':domain:notification:connector:interfaces')
     implementation project(':domain:notification:api:api-model')

--- a/domain/notification/connector/in-bound/src/main/java/com/example/inbound/consumer/member/MemberSignUpRetryTopicConsumer.java
+++ b/domain/notification/connector/in-bound/src/main/java/com/example/inbound/consumer/member/MemberSignUpRetryTopicConsumer.java
@@ -5,6 +5,8 @@ import com.example.logging.MDC.KafkaMDCUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
@@ -14,6 +16,7 @@ import org.springframework.stereotype.Component;
 @AllArgsConstructor
 public class MemberSignUpRetryTopicConsumer {
 
+    @Qualifier("memberKafkaTemplate")
     private final KafkaTemplate<String, MemberSignUpKafkaEvent> kafkaTemplate;
 
     private final MeterRegistry meterRegistry;

--- a/domain/notification/connector/in-bound/src/main/java/com/example/inbound/consumer/schedule/NotificationRetryTopicConsumer.java
+++ b/domain/notification/connector/in-bound/src/main/java/com/example/inbound/consumer/schedule/NotificationRetryTopicConsumer.java
@@ -7,15 +7,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 @Slf4j
+@Profile("!test")
 @Component
 @AllArgsConstructor
 public class NotificationRetryTopicConsumer {
 
+    @Qualifier("notificationKafkaTemplate")
     private final KafkaTemplate<String, NotificationEvents> kafkaTemplate;
 
     private final ObjectMapper objectMapper;

--- a/domain/notification/connector/out-bound/api-client/src/main/java/com/example/apiclient/config/kafka/KafkaConsumerConfig.java
+++ b/domain/notification/connector/out-bound/api-client/src/main/java/com/example/apiclient/config/kafka/KafkaConsumerConfig.java
@@ -5,6 +5,7 @@ import com.example.events.kafka.NotificationEvents;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,6 +21,7 @@ import org.springframework.util.backoff.FixedBackOff;
 
 import java.util.HashMap;
 import java.util.Map;
+
 
 @Configuration
 public class KafkaConsumerConfig {
@@ -79,7 +81,7 @@ public class KafkaConsumerConfig {
     // dlq 설정
     @Bean(name = "notificationKafkaListenerFactory")
     public ConcurrentKafkaListenerContainerFactory<String, NotificationEvents> notificationKafkaListenerFactory(
-            KafkaTemplate<String, NotificationEvents> kafkaTemplate
+            @Qualifier("notificationKafkaTemplate") KafkaTemplate<String, NotificationEvents> kafkaTemplate
     ) {
         ConcurrentKafkaListenerContainerFactory<String, NotificationEvents> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
@@ -100,7 +102,7 @@ public class KafkaConsumerConfig {
 
     @Bean(name = "memberKafkaListenerFactory")
     public ConcurrentKafkaListenerContainerFactory<String, MemberSignUpKafkaEvent> memberKafkaListenerFactory(
-            KafkaTemplate<String, MemberSignUpKafkaEvent> kafkaTemplate
+            @Qualifier("memberKafkaTemplate") KafkaTemplate<String, MemberSignUpKafkaEvent> kafkaTemplate
     ) {
         ConcurrentKafkaListenerContainerFactory<String, MemberSignUpKafkaEvent> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();

--- a/domain/notification/connector/out-bound/api-client/src/main/java/com/example/apiclient/config/kafka/KafkaProducerConfig.java
+++ b/domain/notification/connector/out-bound/api-client/src/main/java/com/example/apiclient/config/kafka/KafkaProducerConfig.java
@@ -7,6 +7,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
@@ -48,6 +49,7 @@ public class KafkaProducerConfig {
         return new DefaultKafkaProducerFactory<>(config);
     }
 
+    @Primary
     @Bean(name = "objectKafkaTemplate")
     public KafkaTemplate<String, Object> objectKafkaTemplate() {
         Map<String, Object> config = new HashMap<>();

--- a/domain/notification/connector/out-bound/src/main/java/com/example/outbound/producer/MemberSignUpKafkaEventProducer.java
+++ b/domain/notification/connector/out-bound/src/main/java/com/example/outbound/producer/MemberSignUpKafkaEventProducer.java
@@ -3,14 +3,18 @@ package com.example.outbound.producer;
 import com.example.events.kafka.MemberSignUpKafkaEvent;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 @Slf4j
+@Profile("!test")
 @Component
 @AllArgsConstructor
 public class MemberSignUpKafkaEventProducer {
 
+    @Qualifier("memberKafkaTemplate")
     private final KafkaTemplate<String, MemberSignUpKafkaEvent> memberKafkaTemplate;
     private static final String TOPIC = "member-signup-events";
 

--- a/domain/notification/connector/out-bound/src/main/java/com/example/outbound/producer/NotificationEventProducer.java
+++ b/domain/notification/connector/out-bound/src/main/java/com/example/outbound/producer/NotificationEventProducer.java
@@ -3,14 +3,18 @@ package com.example.outbound.producer;
 import com.example.events.kafka.NotificationEvents;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 @Slf4j
+@Profile("!test")
 @Component
 @AllArgsConstructor
 public class NotificationEventProducer {
 
+    @Qualifier("notificationKafkaTemplate")
     private final KafkaTemplate<String, NotificationEvents> kafkaTemplate;
 
     private static final String TOPIC_NAME = "notification-events"; // Kafka 토픽명


### PR DESCRIPTION
- 회원가입/일정 컨슈머 멱등성 로직 추가

    - 동일 eventId 수신 시 중복 이벤트 무시 처리 (ProcessedEventService 활용)

    - DB 제약조건(event_id unique)과 로직 중복 방어 이중화

- OutboxPublisher 수정

    - Outbox 저장 시 eventId 매핑 보장 (PK 기반)

   - Kafka 발행 시 기존 eventId 덮어쓰기 방지 → 없는 경우에만 세팅

- 테스트 코드 추가

    - MemberSignUpKafkaEvent 중복 이벤트 수신 → 단일 저장 검증

    - NotificationEvents 중복 이벤트 수신 → 단일 저장 검증

    - DLQ → Retry → 최종 처리 플로우까지 통합 검증

- 수정 이유

   - 운영 환경에서 중복 메시지(재전송, 더블 서브밋 등) 로 인한 데이터 불일치 방지 필요

   - Outbox 패턴 적용 시 eventId 관리 누락 가능성을 사전에 차단

   - 테스트/운영 설정 혼용 문제를 정리해 통합 테스트 안정화

- 검증 방법

   - KafkaIntegrationTest 실행

   - 중복 이벤트 테스트 → 동일 eventId 메시지 2번 발행 시 알림은 1건만 저장됨